### PR TITLE
remove the infamous "_gatsby-scripts"

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -53,7 +53,7 @@ exports.onPreRenderHTML = (
       );
 
       postBody = postBody.filter(
-        (i) => i.type !== 'script' || ('type' in i.props && !scriptType.has(i.props.type)),
+        (i) => i.type !== 'script' || !(i.props.sliceId && i.props.sliceId === '_gatsby-scripts') || ('type' in i.props && !scriptType.has(i.props.type)),
       );
     }
 


### PR DESCRIPTION
remove the infamous "_gatsby-scripts" slices, added in Gatsby 5.2.0